### PR TITLE
test: Selenium acceptance test suite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,8 @@ DB_PASSWORD=your_password
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
+
+# Selenium acceptance tests (mvn test -Pacceptance). Only needed when running acceptance tests.
+# The user must already exist in Supabase auth.users with email_confirmed_at set.
+TEST_USER_EMAIL=acceptance.tester@example.com
+TEST_USER_PASSWORD=ChangeMe!123

--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ The frontend will be available at `http://localhost:3000`.
 
 ---
 
+## Testing
+
+- **Backend unit and integration tests:** `cd backend && mvn test`
+- **Selenium acceptance tests (UI end-to-end):** requires the stack running
+  (`docker compose up -d`) and a confirmed Supabase user. See
+  [backend/README.md](backend/README.md#acceptance-tests-selenium) for setup and
+  the `mvn test -Pacceptance` command.
+
 ## Git Workflow
 
 See [GitWorkflow.md](GitWorkflow.md) for the branching and contribution strategy.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,8 @@ DB_PASSWORD=your_db_password
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
+
+# Selenium acceptance tests (mvn test -Pacceptance). The user must already exist in
+# auth.users with email_confirmed_at set. See backend/README.md for setup details.
+TEST_USER_EMAIL=acceptance.tester@example.com
+TEST_USER_PASSWORD=ChangeMe!123

--- a/backend/README.md
+++ b/backend/README.md
@@ -57,3 +57,72 @@ src/main/java/com/example/
 3. The API will be available at `http://localhost:8080`
 
 4. Swagger UI: `http://localhost:8080/swagger-ui.html`
+
+## Testing
+
+### Unit and integration tests
+
+```bash
+mvn test
+```
+
+Runs every test under `src/test/java` **except** acceptance tests, which are excluded
+via a surefire filter on `**/*AcceptanceTest.java`.
+
+### Acceptance tests (Selenium)
+
+End-to-end tests that drive the React UI in headless Chrome. They mirror the
+[book-api-acceptance-selenium](https://github.com/dipina/book-api-acceptance-selenium)
+example with one structural difference: the frontend is a separate container, so the
+tests do **not** boot the app via `@SpringBootTest`. The full stack must be running
+beforehand.
+
+Tests live in `src/test/java/com/example/restapi/acceptance/`:
+
+| File | What it covers |
+|---|---|
+| `BaseAcceptanceTest.java` | Shared setup: health-check, headless Chrome driver, `loginAsTestUser()` helper |
+| `RegisterLoginAcceptanceTest.java` | Login with valid and invalid credentials |
+| `PlantBrowsingAcceptanceTest.java` | Plant grid and details modal |
+| `CartCheckoutAcceptanceTest.java` | Add to cart, simulated checkout, receipt |
+| `PurchaseSalesHistoryAcceptanceTest.java` | Purchases and Sales tabs render |
+
+#### Prerequisites
+
+1. **Google Chrome** installed locally (WebDriverManager handles the driver automatically).
+2. **The stack must be running** at `http://localhost` (frontend nginx) and
+   `http://localhost:8080` (backend). The easiest way is Docker:
+
+   ```bash
+   docker compose up -d --build
+   ```
+
+3. **A confirmed Supabase user.** The tests log in with credentials read from the
+   environment:
+
+   ```env
+   TEST_USER_EMAIL=acceptance.tester@example.com
+   TEST_USER_PASSWORD=ChangeMe!123
+   ```
+
+   The user must exist in `auth.users` with `email_confirmed_at` set, and have a
+   matching row in `public.profiles`. The repository ships with one already seeded
+   in the shared Supabase project (see `backend/.env`).
+
+#### Running
+
+```bash
+cd backend
+mvn test -Pacceptance
+```
+
+Only `**/*AcceptanceTest.java` runs under this profile. The default `mvn test` skips
+them so CI doesn't need a browser.
+
+#### Notes
+
+- The fake `PaymentService` rejects ~10% of payments at random. `CartCheckoutAcceptanceTest`
+  retries the checkout up to 4 times to keep flakiness negligible.
+- The catalogue test assumes at least one item exists; the project ships with 8.
+- The shared Supabase project must allow the seeded user to remain confirmed —
+  do not delete the user manually.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -30,6 +30,9 @@
 	<properties>
 		<java.version>21</java.version> <server.hostname>127.0.0.1</server.hostname>
 		<server.port>8080</server.port>
+		<selenium.version>4.29.0</selenium.version>
+		<webdrivermanager.version>5.9.2</webdrivermanager.version>
+		<acceptance.baseUrl>http://localhost</acceptance.baseUrl>
 	</properties>
 
 	<dependencies>
@@ -40,6 +43,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
 		<dependency>
@@ -92,6 +100,20 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Selenium for acceptance tests (activated via -Pacceptance) -->
+		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-java</artifactId>
+			<version>${selenium.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.github.bonigarcia</groupId>
+			<artifactId>webdrivermanager</artifactId>
+			<version>${webdrivermanager.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
@@ -113,12 +135,16 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 
-			<!-- Allows jtwig/parboiled reflection needed by JUnitPerf HTML reports on Java 21 -->
+			<!-- Allows jtwig/parboiled reflection needed by JUnitPerf HTML reports on Java 21.
+			     Acceptance tests (*AcceptanceTest.java) are excluded by default; run them with -Pacceptance. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<argLine>@{argLine} --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+					<excludes>
+						<exclude>**/*AcceptanceTest.java</exclude>
+					</excludes>
 				</configuration>
 			</plugin>
 
@@ -226,4 +252,29 @@
 			</plugin>
 		</plugins>
 	</reporting>
+
+	<profiles>
+		<!-- Selenium acceptance tests. Requires the full stack running (docker compose up -d). -->
+		<profile>
+			<id>acceptance</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<argLine>@{argLine} --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+							<excludes combine.self="override" />
+							<includes>
+								<include>**/*AcceptanceTest.java</include>
+							</includes>
+							<systemPropertyVariables>
+								<acceptance.baseUrl>${acceptance.baseUrl}</acceptance.baseUrl>
+							</systemPropertyVariables>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/backend/src/test/java/com/example/restapi/acceptance/BaseAcceptanceTest.java
+++ b/backend/src/test/java/com/example/restapi/acceptance/BaseAcceptanceTest.java
@@ -1,0 +1,124 @@
+package com.example.restapi.acceptance;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+
+/**
+ * Base for Selenium acceptance tests. Mirrors dipina/book-api-acceptance-selenium with
+ * one key difference: the stack (Spring Boot + React via nginx) must already be running
+ * — these tests do NOT boot the app via @SpringBootTest because the frontend is a
+ * separate container. Run the stack with `docker compose up -d` before `mvn test -Pacceptance`.
+ */
+public abstract class BaseAcceptanceTest {
+
+    protected static final String BASE_URL =
+            System.getProperty("acceptance.baseUrl", "http://localhost");
+
+    protected static final String TEST_USER_EMAIL =
+            envOrProperty("TEST_USER_EMAIL", "test.user@example.com");
+
+    protected static final String TEST_USER_PASSWORD =
+            envOrProperty("TEST_USER_PASSWORD", "ChangeMe!123");
+
+    protected static final Duration DEFAULT_WAIT = Duration.ofSeconds(15);
+
+    protected WebDriver driver;
+    protected WebDriverWait wait;
+
+    @BeforeAll
+    static void waitForStack() throws Exception {
+        // Health-check via Spring Boot Actuator. The backend container exposes 8080
+        // directly; nginx (port 80) does NOT proxy /actuator, so we hit 8080.
+        String healthUrl = backendHealthUrl();
+        long deadline = System.currentTimeMillis() + 60_000L;
+        Exception last = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                HttpURLConnection conn = (HttpURLConnection) URI.create(healthUrl).toURL().openConnection();
+                conn.setConnectTimeout(2000);
+                conn.setReadTimeout(2000);
+                conn.setRequestMethod("GET");
+                int code = conn.getResponseCode();
+                conn.disconnect();
+                if (code == 200) {
+                    return;
+                }
+            } catch (Exception e) {
+                last = e;
+            }
+            Thread.sleep(1000);
+        }
+        throw new IllegalStateException(
+                "Backend not reachable at " + healthUrl
+                        + " — start the stack with `docker compose up -d` before running -Pacceptance",
+                last);
+    }
+
+    @BeforeEach
+    void setUpDriver() {
+        WebDriverManager.chromedriver().setup();
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments(
+                "--headless=new",
+                "--no-sandbox",
+                "--disable-dev-shm-usage",
+                "--window-size=1366,900");
+        driver = new ChromeDriver(options);
+        wait = new WebDriverWait(driver, DEFAULT_WAIT);
+    }
+
+    @AfterEach
+    void tearDownDriver() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+
+    /** Drives the React login form with the seeded test user and waits for the dashboard. */
+    protected void loginAsTestUser() {
+        driver.get(BASE_URL + "/");
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='login-email']")))
+                .sendKeys(TEST_USER_EMAIL);
+        driver.findElement(By.cssSelector("[data-testid='login-password']")).sendKeys(TEST_USER_PASSWORD);
+        driver.findElement(By.cssSelector("[data-testid='login-submit']")).click();
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='dashboard-shell']")));
+    }
+
+    /** Convenience: first element matching the selector, or null if none. */
+    protected WebElement firstOrNull(By by) {
+        var elements = driver.findElements(by);
+        return elements.isEmpty() ? null : elements.get(0);
+    }
+
+    private static String backendHealthUrl() {
+        // BASE_URL is the URL Selenium navigates to (frontend, typically http://localhost).
+        // Health-check always goes to the backend on 8080.
+        return "http://localhost:8080/actuator/health";
+    }
+
+    private static String envOrProperty(String name, String fallback) {
+        String fromEnv = System.getenv(name);
+        if (fromEnv != null && !fromEnv.isBlank()) {
+            return fromEnv;
+        }
+        String fromProp = System.getProperty(name);
+        if (fromProp != null && !fromProp.isBlank()) {
+            return fromProp;
+        }
+        return fallback;
+    }
+}

--- a/backend/src/test/java/com/example/restapi/acceptance/CartCheckoutAcceptanceTest.java
+++ b/backend/src/test/java/com/example/restapi/acceptance/CartCheckoutAcceptanceTest.java
@@ -1,0 +1,104 @@
+package com.example.restapi.acceptance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+/**
+ * Acceptance test for the cart + checkout flow. Adds the first available plant to the
+ * cart, opens the cart sidebar, runs the simulated checkout and asserts the receipt.
+ *
+ * PaymentService rejects ~10% of payments at random, so checkout is retried up to
+ * {@link #CHECKOUT_RETRIES} times — leaving the cumulative failure rate negligible.
+ */
+class CartCheckoutAcceptanceTest extends BaseAcceptanceTest {
+
+    private static final int CHECKOUT_RETRIES = 4;
+
+    @Test
+    @DisplayName("user adds an item, checks out and sees the receipt")
+    void addItemAndCheckoutSucceeds() {
+        loginAsTestUser();
+
+        // 1. Open the first plant and add 1 unit to the cart.
+        wait.until(d -> !d.findElements(By.cssSelector("[data-testid='plant-view-details']")).isEmpty());
+        driver.findElements(By.cssSelector("[data-testid='plant-view-details']")).get(0).click();
+
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='plant-details-modal']")));
+        // The modal mounts immediately but renders a spinner while plant details load —
+        // wait for the quantity input itself, which only appears once data has arrived.
+        // The input is pre-filled with 1 via React state, so we leave it untouched
+        // (typing into it cross-platform is unreliable: Ctrl+A doesn't select on macOS).
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='plant-quantity']")));
+        wait.until(ExpectedConditions.elementToBeClickable(By.cssSelector("[data-testid='plant-add-to-cart']")))
+                .click();
+
+        // The modal closes itself after a 1.5s success message. Wait for it to be gone.
+        wait.until(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector("[data-testid='plant-details-modal']")));
+
+        // 2. Open the cart, expect at least one item.
+        driver.findElement(By.cssSelector("[data-testid='open-cart']")).click();
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='cart-sidebar']")));
+        wait.until(d -> !d.findElements(By.cssSelector("[data-testid='cart-item']")).isEmpty());
+
+        assertFalse(driver.findElements(By.cssSelector("[data-testid='cart-item']")).isEmpty(),
+                "Cart should contain the item we just added");
+
+        // 3. Run checkout. Retry on the random 10% payment failure.
+        driver.findElement(By.cssSelector("[data-testid='cart-checkout']")).click();
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='checkout-modal']")));
+
+        boolean receiptShown = false;
+        for (int attempt = 0; attempt < CHECKOUT_RETRIES && !receiptShown; attempt++) {
+            fillCheckoutForm();
+            driver.findElement(By.cssSelector("[data-testid='checkout-submit']")).click();
+
+            WebDriverWait outcome = new WebDriverWait(driver, Duration.ofSeconds(20));
+            receiptShown = outcome.until(d -> {
+                if (!d.findElements(By.cssSelector("[data-testid='receipt-modal']")).isEmpty()) {
+                    return true;
+                }
+                // Payment failed (simulated). The form stays open with a .checkout-error message.
+                return !d.findElements(By.className("checkout-error")).isEmpty();
+            });
+
+            if (!driver.findElements(By.cssSelector("[data-testid='receipt-modal']")).isEmpty()) {
+                receiptShown = true;
+            } else {
+                // Clear the error and retry — the form is still on screen and re-fillable.
+                receiptShown = false;
+            }
+        }
+
+        assertTrue(receiptShown,
+                "Checkout did not produce a receipt after " + CHECKOUT_RETRIES + " attempts");
+
+        WebElement receiptNumber = wait.until(
+                ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='receipt-number']")));
+        assertFalse(receiptNumber.getText().isBlank(), "Receipt number should be present");
+
+        driver.findElement(By.cssSelector("[data-testid='receipt-continue']")).click();
+        wait.until(ExpectedConditions.invisibilityOfElementLocated(By.cssSelector("[data-testid='receipt-modal']")));
+    }
+
+    private void fillCheckoutForm() {
+        setText(By.cssSelector("[data-testid='checkout-card-number']"), "4111111111111111");
+        setText(By.cssSelector("[data-testid='checkout-card-holder']"), "Acceptance Test");
+        setText(By.cssSelector("[data-testid='checkout-expiry']"), "1230");
+        setText(By.cssSelector("[data-testid='checkout-cvv']"), "123");
+    }
+
+    private void setText(By by, String text) {
+        WebElement el = driver.findElement(by);
+        el.clear();
+        el.sendKeys(text);
+    }
+}

--- a/backend/src/test/java/com/example/restapi/acceptance/PlantBrowsingAcceptanceTest.java
+++ b/backend/src/test/java/com/example/restapi/acceptance/PlantBrowsingAcceptanceTest.java
@@ -1,0 +1,50 @@
+package com.example.restapi.acceptance;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+/**
+ * Acceptance test for the plant catalogue: a logged-in user sees the plants grid and
+ * can open the details modal of any plant. Assumes at least one item exists in the DB
+ * (created via the app or fixtures).
+ */
+class PlantBrowsingAcceptanceTest extends BaseAcceptanceTest {
+
+    @Test
+    @DisplayName("logged-in user sees plant cards on the shop tab")
+    void plantsGridShowsCards() {
+        loginAsTestUser();
+
+        // Shop tab is the default. Wait for the grid to render and then for at least one card.
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='plants-grid']")));
+        wait.until(d -> !d.findElements(By.cssSelector("[data-testid='plant-card']")).isEmpty());
+
+        List<WebElement> cards = driver.findElements(By.cssSelector("[data-testid='plant-card']"));
+        assertFalse(cards.isEmpty(),
+                "Expected at least one plant in the catalogue. "
+                        + "Seed one via the UI ('+ Create post') or directly in the DB before running this test.");
+    }
+
+    @Test
+    @DisplayName("clicking 'View details' opens the plant details modal")
+    void clickingViewDetailsOpensModal() {
+        loginAsTestUser();
+
+        wait.until(d -> !d.findElements(By.cssSelector("[data-testid='plant-view-details']")).isEmpty());
+        driver.findElements(By.cssSelector("[data-testid='plant-view-details']")).get(0).click();
+
+        WebElement modal = wait.until(
+                ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='plant-details-modal']")));
+        assertTrue(modal.isDisplayed(), "Plant details modal should appear after clicking 'View details'");
+        // The add-to-cart button is what makes this modal actionable.
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='plant-add-to-cart']")));
+    }
+}

--- a/backend/src/test/java/com/example/restapi/acceptance/PurchaseSalesHistoryAcceptanceTest.java
+++ b/backend/src/test/java/com/example/restapi/acceptance/PurchaseSalesHistoryAcceptanceTest.java
@@ -1,0 +1,44 @@
+package com.example.restapi.acceptance;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+/**
+ * Acceptance test for the Purchases and Sales tabs of the dashboard. Verifies that
+ * each tab renders its container without errors — either showing real records or the
+ * empty-state placeholder, both are valid outcomes.
+ */
+class PurchaseSalesHistoryAcceptanceTest extends BaseAcceptanceTest {
+
+    @Test
+    @DisplayName("Purchases tab renders the purchase history view")
+    void purchaseTabRenders() {
+        loginAsTestUser();
+
+        driver.findElement(By.cssSelector("[data-testid='tab-purchases']")).click();
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='purchase-history']")));
+
+        boolean rendered =
+                !driver.findElements(By.cssSelector("[data-testid='purchase-card']")).isEmpty()
+                        || !driver.findElements(By.cssSelector("[data-testid='purchase-history-empty']")).isEmpty();
+        assertTrue(rendered, "Purchase history should render either cards or empty-state placeholder");
+    }
+
+    @Test
+    @DisplayName("Sales tab renders the sales history view")
+    void salesTabRenders() {
+        loginAsTestUser();
+
+        driver.findElement(By.cssSelector("[data-testid='tab-sales']")).click();
+        wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='sales-history']")));
+
+        boolean rendered =
+                !driver.findElements(By.cssSelector("[data-testid='sale-card']")).isEmpty()
+                        || !driver.findElements(By.cssSelector("[data-testid='sales-history-empty']")).isEmpty();
+        assertTrue(rendered, "Sales history should render either cards or empty-state placeholder");
+    }
+}

--- a/backend/src/test/java/com/example/restapi/acceptance/RegisterLoginAcceptanceTest.java
+++ b/backend/src/test/java/com/example/restapi/acceptance/RegisterLoginAcceptanceTest.java
@@ -1,0 +1,43 @@
+package com.example.restapi.acceptance;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+
+/**
+ * Smoke acceptance test: the seeded user (TEST_USER_EMAIL / TEST_USER_PASSWORD) can
+ * sign in through the React UI and reach the dashboard. Verifies the full stack is
+ * wired end-to-end (frontend → nginx → backend → Supabase).
+ */
+class RegisterLoginAcceptanceTest extends BaseAcceptanceTest {
+
+    @Test
+    @DisplayName("seeded user logs in and lands on the dashboard")
+    void loginSucceedsAndShowsDashboard() {
+        loginAsTestUser();
+        WebElement dashboard = driver.findElement(By.cssSelector("[data-testid='dashboard-shell']"));
+        assertTrue(dashboard.isDisplayed(), "Dashboard shell should be visible after login");
+    }
+
+    @Test
+    @DisplayName("invalid credentials surface an error and stay on the login screen")
+    void invalidCredentialsShowError() {
+        driver.get(BASE_URL + "/");
+
+        WebElement emailInput = wait.until(
+                ExpectedConditions.visibilityOfElementLocated(By.cssSelector("[data-testid='login-email']")));
+        emailInput.sendKeys("nobody+" + System.currentTimeMillis() + "@example.com");
+        driver.findElement(By.cssSelector("[data-testid='login-password']")).sendKeys("wrong-password");
+        driver.findElement(By.cssSelector("[data-testid='login-submit']")).click();
+
+        // App routes 404 (unknown email) to the Register screen, and 401 to an inline error.
+        // Both are valid "did not reach the dashboard" outcomes — assert the dashboard is NOT shown.
+        boolean stillOutsideDashboard = wait.until(d ->
+                d.findElements(By.cssSelector("[data-testid='dashboard-shell']")).isEmpty());
+        assertTrue(stillOutsideDashboard, "Login with bad credentials must not reach the dashboard");
+    }
+}

--- a/frontend/src/Cart.js
+++ b/frontend/src/Cart.js
@@ -86,7 +86,7 @@ export default function Cart({ userId, onClose, onCartLoad }) {
 
   return (
     <>
-      <aside className="cart-sidebar">
+      <aside className="cart-sidebar" data-testid="cart-sidebar">
         <div className="cart-header">
           <h2>{t("cart.title")}</h2>
           <button
@@ -128,9 +128,9 @@ export default function Cart({ userId, onClose, onCartLoad }) {
             </div>
             <div className="cart-items-container">
               {cartData.items.map((item) => (
-                <div key={item.itemId} className="cart-item">
+                <div key={item.itemId} className="cart-item" data-testid="cart-item">
                   <div className="cart-item-info">
-                    <h4>{item.title}</h4>
+                    <h4 data-testid="cart-item-title">{item.title}</h4>
                     <p className="cart-item-price">{formatCurrency(item.amount)}</p>
                   </div>
                   <div className="cart-item-quantity">
@@ -165,6 +165,7 @@ export default function Cart({ userId, onClose, onCartLoad }) {
 
             <button
               className="primary-button cart-checkout-button"
+              data-testid="cart-checkout"
               onClick={() => setShowCheckout(true)}
               disabled={updating}
             >

--- a/frontend/src/Checkout.js
+++ b/frontend/src/Checkout.js
@@ -98,7 +98,7 @@ export default function Checkout({ userId, cartTotal, onCheckoutSuccess, onCance
 
   return (
     <div className="checkout-overlay">
-      <div className="checkout-modal">
+      <div className="checkout-modal" data-testid="checkout-modal">
         <div className="checkout-header">
           <h2>{t("checkout.title")}</h2>
           <button
@@ -124,6 +124,7 @@ export default function Checkout({ userId, cartTotal, onCheckoutSuccess, onCance
               type="text"
               id="cardNumber"
               name="cardNumber"
+              data-testid="checkout-card-number"
               placeholder="1234 5678 9012 3456"
               value={formData.cardNumber}
               onChange={handleInputChange}
@@ -139,6 +140,7 @@ export default function Checkout({ userId, cartTotal, onCheckoutSuccess, onCance
               type="text"
               id="cardHolder"
               name="cardHolder"
+              data-testid="checkout-card-holder"
               placeholder="Aretx Oca"
               value={formData.cardHolder}
               onChange={handleInputChange}
@@ -154,6 +156,7 @@ export default function Checkout({ userId, cartTotal, onCheckoutSuccess, onCance
                 type="text"
                 id="expiryDate"
                 name="expiryDate"
+                data-testid="checkout-expiry"
                 placeholder="MM/YY"
                 value={formData.expiryDate}
                 onChange={handleInputChange}
@@ -169,6 +172,7 @@ export default function Checkout({ userId, cartTotal, onCheckoutSuccess, onCance
                 type="text"
                 id="cvv"
                 name="cvv"
+                data-testid="checkout-cvv"
                 placeholder="123"
                 value={formData.cvv}
                 onChange={handleInputChange}
@@ -195,6 +199,7 @@ export default function Checkout({ userId, cartTotal, onCheckoutSuccess, onCance
             <button
               type="submit"
               className="primary-button"
+              data-testid="checkout-submit"
               disabled={loading}
             >
               {loading ? t("common.actions.processing") : t("common.actions.completePayment")}

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -158,7 +158,7 @@ export default function Dashboard({ user, onLogout }) {
   };
 
   return (
-    <main className="dashboard-shell">
+    <main className="dashboard-shell" data-testid="dashboard-shell">
       <header className="dashboard-topbar">
         <div>
           <p className="dashboard-eyebrow">{t("common.brand")}</p>
@@ -186,6 +186,7 @@ export default function Dashboard({ user, onLogout }) {
           <button
             className="cart-button"
             type="button"
+            data-testid="open-cart"
             aria-label={t("dashboard.openCartAria")}
             onClick={() => setShowCart((current) => !current)}
           >
@@ -211,6 +212,7 @@ export default function Dashboard({ user, onLogout }) {
             <button
               className="profile-button"
               type="button"
+              data-testid="profile-toggle"
               aria-label={t("dashboard.profileAria")}
               onClick={() => setShowProfile((current) => !current)}
             >
@@ -245,7 +247,7 @@ export default function Dashboard({ user, onLogout }) {
                     })}</dd>
                   </div>
                 </dl>
-                <button className="secondary-button profile-logout" type="button" onClick={onLogout}>
+                <button className="secondary-button profile-logout" type="button" data-testid="logout-button" onClick={onLogout}>
                   {t("common.actions.signOut")}
                 </button>
               </aside>
@@ -294,20 +296,23 @@ export default function Dashboard({ user, onLogout }) {
         <div className="catalogue-header">
           <h2 className="catalogue-title">{t("dashboard.catalogueTitle")}</h2>
           <div className="dashboard-tabs">
-            <button 
+            <button
               className={`tab-button${dashboardTab === "shop" ? " active" : ""}`}
+              data-testid="tab-shop"
               onClick={() => setDashboardTab("shop")}
             >
               {t("dashboard.shoppingTab")}
             </button>
-            <button 
+            <button
               className={`tab-button${dashboardTab === "purchases" ? " active" : ""}`}
+              data-testid="tab-purchases"
               onClick={() => setDashboardTab("purchases")}
             >
               {t("dashboard.purchasesTab")}
             </button>
-            <button 
+            <button
               className={`tab-button${dashboardTab === "sales" ? " active" : ""}`}
+              data-testid="tab-sales"
               onClick={() => setDashboardTab("sales")}
             >
               {t("dashboard.salesTab")}
@@ -345,16 +350,17 @@ export default function Dashboard({ user, onLogout }) {
                 <p className="auth-error">Error: {translateError(error)}</p>
               ) : filteredPlants.length > 0 ? (
                 filteredPlants.map(plant => (
-                  <div key={plant.id} className="auth-card plant-card">
+                  <div key={plant.id} className="auth-card plant-card" data-testid="plant-card">
                     <div className="plant-image-container">
                       <img src={plant.image} alt={plant.name} />
                     </div>
                     <div className="plant-content">
                       <span className="auth-kicker">{translateCategory(plant.type)}</span>
-                      <h3>{plant.name}</h3>
+                      <h3 data-testid="plant-card-name">{plant.name}</h3>
                       <p className="price-tag">{formatCurrency(plant.price)}</p>
-                      <button 
+                      <button
                         className="primary-button"
+                        data-testid="plant-view-details"
                         onClick={() => setSelectedPlantId(plant.id)}
                       >
                         {t("common.actions.viewDetails")}

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -101,6 +101,7 @@ export default function Login({ onLoginSuccess, showRegister, successMsg }) {
         <div className="auth-fields">
           <input
             className="auth-input"
+            data-testid="login-email"
             placeholder={t("common.labels.email")}
             type="email"
             value={email}
@@ -108,6 +109,7 @@ export default function Login({ onLoginSuccess, showRegister, successMsg }) {
           />
           <input
             className="auth-input"
+            data-testid="login-password"
             placeholder={t("common.labels.password")}
             type="password"
             value={password}
@@ -130,8 +132,8 @@ export default function Login({ onLoginSuccess, showRegister, successMsg }) {
           )}
         </div>
         <div className="auth-actions">
-          <button className="primary-button" onClick={handleLogin}>{t("common.actions.login")}</button>
-          <button className="secondary-button" onClick={showRegister}>{t("common.actions.createAccount")}</button>
+          <button className="primary-button" data-testid="login-submit" onClick={handleLogin}>{t("common.actions.login")}</button>
+          <button className="secondary-button" data-testid="login-go-register" onClick={showRegister}>{t("common.actions.createAccount")}</button>
         </div>
 
         {emailNotConfirmed && (
@@ -155,7 +157,7 @@ export default function Login({ onLoginSuccess, showRegister, successMsg }) {
           </div>
         )}
 
-        {error && <p className="auth-error">{error}</p>}
+        {error && <p className="auth-error" data-testid="login-error">{error}</p>}
       </section>
     </main>
   );

--- a/frontend/src/PlantDetailsModal.js
+++ b/frontend/src/PlantDetailsModal.js
@@ -82,7 +82,7 @@ export default function PlantDetailsModal({ plantId, userId, onClose, onItemAdde
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content plant-details-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal-content plant-details-modal" data-testid="plant-details-modal" onClick={(e) => e.stopPropagation()}>
         {loading ? (
           <p className="auth-error">{t("plantDetails.loading")}</p>
         ) : plantDetails ? (
@@ -133,6 +133,7 @@ export default function PlantDetailsModal({ plantId, userId, onClose, onItemAdde
                   <label htmlFor="quantity">{t("plantDetails.quantityLabel")}</label>
                   <input
                     id="quantity"
+                    data-testid="plant-quantity"
                     type="number"
                     min="1"
                     max={plantDetails.quantity}
@@ -144,6 +145,7 @@ export default function PlantDetailsModal({ plantId, userId, onClose, onItemAdde
 
                 <button
                   className="primary-button"
+                  data-testid="plant-add-to-cart"
                   onClick={handleAddToCart}
                   disabled={addingToCart}
                 >

--- a/frontend/src/PurchaseHistory.js
+++ b/frontend/src/PurchaseHistory.js
@@ -158,13 +158,13 @@ export default function PurchaseHistory({ userId }) {
   }
 
   return (
-    <div className="history-container">
+    <div className="history-container" data-testid="purchase-history">
       <h2>{t("purchaseHistory.title")}</h2>
 
       {error && <div className="history-error">{error}</div>}
 
       {purchases.length === 0 ? (
-        <div className="history-empty">
+        <div className="history-empty" data-testid="purchase-history-empty">
           <p>{t("purchaseHistory.empty")}</p>
         </div>
       ) : (
@@ -206,7 +206,7 @@ export default function PurchaseHistory({ userId }) {
           <div className="receipts-list">
             <h3>{t("purchaseHistory.recentOrders")}</h3>
             {purchases.map((purchase) => (
-              <div key={purchase.receiptId} className="receipt-card">
+              <div key={purchase.receiptId} className="receipt-card" data-testid="purchase-card">
                 <div className="receipt-card-header">
                   <div className="receipt-info">
                     <p className="receipt-number">{purchase.receiptNumber}</p>

--- a/frontend/src/Receipt.js
+++ b/frontend/src/Receipt.js
@@ -6,7 +6,7 @@ export default function Receipt({ receipt, onClose }) {
 
   return (
     <div className="receipt-overlay">
-      <div className="receipt-modal">
+      <div className="receipt-modal" data-testid="receipt-modal">
         <div className="receipt-header">
           <h2>{t("receipt.successTitle")}</h2>
           <button
@@ -21,7 +21,7 @@ export default function Receipt({ receipt, onClose }) {
         <div className="receipt-content">
           <div className="receipt-number">
             <p className="label">{t("common.labels.receiptNumber")}:</p>
-            <p className="value">{receipt.receiptNumber}</p>
+            <p className="value" data-testid="receipt-number">{receipt.receiptNumber}</p>
           </div>
 
           <div className="receipt-date">
@@ -84,6 +84,7 @@ export default function Receipt({ receipt, onClose }) {
 
           <button
             className="primary-button receipt-button"
+            data-testid="receipt-continue"
             onClick={onClose}
           >
             {t("common.actions.continueShopping")}

--- a/frontend/src/SalesHistory.js
+++ b/frontend/src/SalesHistory.js
@@ -77,13 +77,13 @@ export default function SalesHistory({ userId }) {
   }
 
   return (
-    <div className="history-container">
+    <div className="history-container" data-testid="sales-history">
       <h2>{t("salesHistory.title")}</h2>
 
       {error && <div className="history-error">{error}</div>}
 
       {sales.length === 0 ? (
-        <div className="history-empty">
+        <div className="history-empty" data-testid="sales-history-empty">
           <p>{t("salesHistory.empty")}</p>
         </div>
       ) : (
@@ -148,7 +148,7 @@ export default function SalesHistory({ userId }) {
           <div className="sales-list">
             <h3>{t("salesHistory.recentSales")}</h3>
             {sales.map((sale, index) => (
-              <div key={index} className="sale-card">
+              <div key={index} className="sale-card" data-testid="sale-card">
                 <div className="sale-card-header">
                   <div className="sale-info">
                     <p className="sale-item">{sale.itemName}</p>


### PR DESCRIPTION
## What does this PR do?

Adds an end-to-end Selenium acceptance test suite that drives the React UI in headless Chrome — mirroring the structure of the professor's [book-api-acceptance-selenium](https://github.com/dipina/book-api-acceptance-selenium) reference, adapted to this project's split frontend/backend setup.

## Type of change

- [x] test – adding or updating tests
- [x] chore – build/dependency changes
- [x] docs – README + .env.example updates

## How to test

1. Start the stack: `docker compose up -d --build`
2. Make sure `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` are set in `backend/.env` (an already-confirmed Supabase user is seeded — see `backend/README.md`)
3. Run: `cd backend && mvn test -Pacceptance`

Expected: **7 tests pass** across 4 classes.

`mvn test` (without `-Pacceptance`) keeps ignoring acceptance tests so CI is unaffected.

## What's in this PR

- **`chore: add Selenium and actuator dependencies`** — `spring-boot-starter-actuator`, `selenium-java 4.29.0`, `webdrivermanager 5.9.2`, surefire exclude + `-Pacceptance` profile.
- **`test: add data-testid hooks`** — stable selectors for Login, Dashboard, PlantDetailsModal, Cart, Checkout, Receipt, PurchaseHistory, SalesHistory. Zero logic changes.
- **`test: add Selenium acceptance test suite`** — `BaseAcceptanceTest` (headless Chrome, actuator health-check, `loginAsTestUser` helper) + four test classes:
  - `RegisterLoginAcceptanceTest` — valid login lands on dashboard; bad credentials don't
  - `PlantBrowsingAcceptanceTest` — catalogue renders and the details modal opens
  - `CartCheckoutAcceptanceTest` — add to cart → simulated payment → receipt (retries against the ~10% random payment failure)
  - `PurchaseSalesHistoryAcceptanceTest` — Purchases and Sales tabs render
- Docs in `backend/README.md` and a pointer in the root `README.md`.
- `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` placeholders in both `.env.example` files.

## Architectural note

The reference project ships frontend and backend as a single Spring Boot app, so its tests boot the app via `@SpringBootTest(RANDOM_PORT)`. Here the React frontend runs in its own container behind nginx, so the tests **assume the stack is already running** (`docker compose up -d`). The base class verifies this with a health-check before the first test.

## Related issues

—

## Checklist

- [x] Code follows the project's coding standards (data-testid only, no logic changes in the frontend)
- [x] Tests added (7 acceptance tests, all green locally)
- [x] Documentation updated (`backend/README.md`, `README.md`)
- [x] Branch is up to date with `main`
- [x] `.env` not committed (only the example placeholders)
- [x] Pre-existing test failures in `AppUserManagerIntegrationTest` and `PerformanceTest` are out of scope (verified to fail identically on `main`)