### PR TITLE
fix(forum): UI polish — grid feed, dedicated modals, hide misleading title

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1259,8 +1259,8 @@
 
 .forum-feed {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 24px;
 }
 
 .forum-post-card {
@@ -1313,4 +1313,50 @@
   margin-top: 24px;
   padding-top: 16px;
   border-top: 1px solid #e2e8db;
+}
+
+/* Post details modal — narrow text-first dialog (default modal width is fine). */
+.post-details-modal {
+  padding: 20px 28px 28px;
+  overflow-y: auto;
+}
+
+.post-details-modal h2 {
+  font-size: 1.6rem;
+  margin: 4px 0 0 0;
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+.post-details-loading {
+  text-align: center;
+  color: var(--text-soft);
+  padding: 32px 0;
+  margin: 0;
+}
+
+.forum-comments-placeholder {
+  color: var(--text-soft);
+  font-style: italic;
+  margin: 8px 0 0 0;
+}
+
+/* Create-forum-post modal — short form, no image upload, compact sizing. */
+.create-forum-post-modal {
+  padding: 0;
+  overflow-y: auto;
+}
+
+/* Override Checkout.css's global .modal-header which lays out as
+   horizontal flex — for stacked title + subtitle we need vertical. */
+.create-forum-post-modal .modal-header,
+.post-details-modal .modal-header {
+  display: block;
+  border-bottom: none;
+  padding: 16px 24px 8px;
+}
+
+.create-forum-post-form {
+  padding: 0 24px;
+  display: grid;
+  gap: 16px;
 }

--- a/frontend/src/CreateForumPost.js
+++ b/frontend/src/CreateForumPost.js
@@ -65,7 +65,7 @@ export default function CreateForumPost({ userId, onClose, onPostCreated }) {
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div
-        className="modal-content create-item-modal"
+        className="modal-content create-forum-post-modal"
         data-testid="create-forum-post-modal"
         onClick={(e) => e.stopPropagation()}
       >
@@ -82,7 +82,7 @@ export default function CreateForumPost({ userId, onClose, onPostCreated }) {
           <p className="form-subtitle">{t("forum.createPost.subtitle")}</p>
         </div>
 
-        <form className="create-item-form" onSubmit={handleSubmit}>
+        <form className="create-forum-post-form" onSubmit={handleSubmit}>
           <div className="form-section">
             <div className="form-group">
               <label htmlFor="forum-post-title">{t("forum.createPost.titleLabel")}</label>

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -295,7 +295,9 @@ export default function Dashboard({ user, onLogout }) {
 
       <section className="andoni-catalogue">
         <div className="catalogue-header">
-          <h2 className="catalogue-title">{t("dashboard.catalogueTitle")}</h2>
+          {dashboardTab === "shop" && (
+            <h2 className="catalogue-title">{t("dashboard.catalogueTitle")}</h2>
+          )}
           <div className="dashboard-tabs">
             <button
               className={`tab-button${dashboardTab === "shop" ? " active" : ""}`}

--- a/frontend/src/PostDetailsModal.js
+++ b/frontend/src/PostDetailsModal.js
@@ -32,7 +32,7 @@ export default function PostDetailsModal({ postId, onClose }) {
   return (
     <div className="modal-overlay" onClick={onClose}>
       <div
-        className="modal-content plant-details-modal"
+        className="modal-content post-details-modal"
         data-testid="post-details-modal"
         onClick={(e) => e.stopPropagation()}
       >
@@ -45,7 +45,7 @@ export default function PostDetailsModal({ postId, onClose }) {
         </button>
 
         {loading ? (
-          <p className="auth-error">{t("forum.postDetails.loading")}</p>
+          <p className="post-details-loading">{t("forum.postDetails.loading")}</p>
         ) : error ? (
           <p className="auth-error">{error}</p>
         ) : post ? (
@@ -83,7 +83,7 @@ export default function PostDetailsModal({ postId, onClose }) {
               data-post-id={post.id}
             >
               <h3>{t("forum.postDetails.commentsTitle")}</h3>
-              <p className="auth-error">{t("forum.postDetails.commentsPlaceholder")}</p>
+              <p className="forum-comments-placeholder">{t("forum.postDetails.commentsPlaceholder")}</p>
             </section>
           </article>
         ) : null}


### PR DESCRIPTION
## Summary

UI polish for the Community tab that landed in #148. Found during a real-browser walk-through; the acceptance suite only validates presence/clicks, not visual fidelity.

## Type of change

- [x] fix — visual / UX issues only, no behavioural change

## How to test

```bash
docker compose up -d --build frontend
# open http://localhost, log in, click "Comunidad"
```

Compare against before — the four issues below should be gone.

## What was wrong

1. **"Catálogo de plantas" header persisted on every tab**, including Community/Purchases/Sales. Now only on Shop.
2. **Feed was a single column** even on wide screens. Now a responsive grid (`repeat(auto-fill, minmax(280px, 1fr))`), matching the plants catalogue.
3. **PostDetailsModal inherited `.plant-details-modal`** which is sized for a two-column image+text layout — looked off for a text-only post. New `.post-details-modal` class.
4. **CreateForumPostModal clipped the Category field** by ~60 px at the bottom because the global `.create-item-form` uses `flex: 1; overflow: auto` designed for a much taller form. New `.create-forum-post-modal` scrolls the modal itself when needed.

Also:
- Comments placeholder ("Los comentarios estarán disponibles próximamente") was painted red via `.auth-error`. Now a neutral gray italic.
- Forum modal header was laid out as horizontal flex (inherited from `Checkout.css`), squashing title and subtitle side by side. Overridden to vertical block for forum modals.

## Files

- `frontend/src/Dashboard.js` — condition `<h2 className="catalogue-title">` on `dashboardTab === "shop"`.
- `frontend/src/PostDetailsModal.js` — use `.post-details-modal`, `.forum-comments-placeholder`, `.post-details-loading`.
- `frontend/src/CreateForumPost.js` — use `.create-forum-post-modal` and `.create-forum-post-form`.
- `frontend/src/App.css` — feed grid + the new modal classes.

## Doesn't touch

- Comments work — still left for the other contributor, the `data-testid="comments-section"` anchor is untouched.
- Tests — the acceptance suite still passes (selectors unchanged).